### PR TITLE
Fix ModSecurity 403 when saving settings

### DIFF
--- a/includes/admin/actions.php
+++ b/includes/admin/actions.php
@@ -56,12 +56,20 @@ function altcha_get_settings_ajax()
 function altcha_set_settings_ajax()
 {
   altcha_ajax_check_access();
-  if (!isset($_POST["data"])) {
+  if (!isset($_POST["data"]) && !isset($_POST["data_b64"])) {
     wp_send_json_error("No data received", 400);
     return;
   }
 
-  $json_data = stripslashes(sanitize_text_field(wp_unslash($_POST["data"])));
+  if (isset($_POST["data_b64"])) {
+    $json_data = base64_decode(str_replace(" ", "+", sanitize_text_field(wp_unslash($_POST["data_b64"]))), true);
+    if ($json_data === false) {
+      wp_send_json_error("Invalid base64 data", 400);
+      return;
+    }
+  } else {
+    $json_data = stripslashes(sanitize_text_field(wp_unslash($_POST["data"])));
+  }
   $data = json_decode($json_data, true);
 
   if (json_last_error() !== JSON_ERROR_NONE) {

--- a/public/admin-wp.js
+++ b/public/admin-wp.js
@@ -76,7 +76,8 @@
     setSettings: async (data) => {
       const body = new FormData();
       body.append('action', 'altcha_set_settings');
-      body.append('data', JSON.stringify(data));
+      // Base64 avoids ModSecurity false positive (rule 981255) on "! in actions/paths
+      body.append('data_b64', btoa(unescape(encodeURIComponent(JSON.stringify(data)))));
       const resp = await fetch(ajaxurl, {
         body,
         method: 'POST',


### PR DESCRIPTION
When actions or paths contain exclusion patterns with a quote followed by an exclamation mark (e.g. "!wc-ajax=*", "!/wp-json/..."), ModSecurity might trigger a false positive and blocks the POST with 403. Sending the settings payload as base64 avoids the pattern match while keeping behavior unchanged.

Backward compatible: server still accepts plain "data" parameter; client sends "data_b64" so requests are not blocked.